### PR TITLE
Set project's language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.* linguist-language=Python


### PR DESCRIPTION
Added .gitattributes file to override default language display  of the project from Github. 